### PR TITLE
Zfssend

### DIFF
--- a/src/bin/poudriere-image.8
+++ b/src/bin/poudriere-image.8
@@ -73,6 +73,8 @@ This specifies the maximum size of the image that is built.
 Name of the snapshot for zsnapshot type.
 .It Fl t Ar type
 This specifies the type of image to create:
+.It Fl Y Ar script
+This specifies the path to a script which will be sourced before exporting the image.
 .Bl -tag -width "rawfirmware"
 .It iso
 An ISO 9660 format image.

--- a/src/bin/poudriere-image.8
+++ b/src/bin/poudriere-image.8
@@ -93,6 +93,14 @@ filesystem is LZ77 compressed and is MFS mounted.
 A raw UFS2, softupdates-enabled, disk image.
 .It zrawdisk
 A raw ZFS disk image.
+.It zfssend
+A ZFS replication stream.
+Defaults to zfssend+be.
+You may specify multiple streams by specifying multiple options (example: zfssend+full+be).
+.It zfssend+be
+Creates a ZFS replication stream of the boot environment.
+.It zfssend+full
+Creates a ZFS replication stream of the while pool, including the boot environment.
 .It tar
 An XZ-compressed tarball.
 .It firmware

--- a/src/share/poudriere/common.sh
+++ b/src/share/poudriere/common.sh
@@ -7658,6 +7658,35 @@ calculate_ospart_size() {
 	msg "OS Partiton size: ${OS_SIZE}m"
 }
 
+
+# Stolen from bsdconfig
+# str_replaceall $string $find $replace [$var_to_set]
+#
+# Replace all occurrences of $find in $string with $replace. If $var_to_set is
+# either missing or NULL, the variable name is produced on standard out for
+# capturing in a sub-shell (which is less recommended due to performance
+# degradation).
+#
+str_replaceall()
+{
+	local __left="" __right="$1"
+	local __find="$2" __replace="$3" __var_to_set="$4"
+	while :; do
+		case "$__right" in *$__find*)
+			__left="$__left${__right%%$__find*}$__replace"
+			__right="${__right#*$__find}"
+			continue
+		esac
+		break
+	done
+	__left="$__left${__right#*$__find}"
+	if [ "$__var_to_set" ]; then
+		setvar "$__var_to_set" "$__left"
+	else
+		echo "$__left"
+	fi
+}
+
 # Builtin-only functions
 _BUILTIN_ONLY=""
 for _var in ${_BUILTIN_ONLY}; do

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -3,7 +3,7 @@
 # Copyright (c) 2015 Baptiste Daroussin <bapt@FreeBSD.org>
 # All rights reserved.
 # Copyright (c) 2018 Allan Jude <allanjude@FreeBSD.org>
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -475,7 +475,8 @@ zfssend*)
 	zroot=${IMAGENAME}root
 	msg "Creating temporary ZFS pool"
 	zpool create \
-		-O mountpoint=/${zroot} \
+		-O mountpoint=/ \
+		-O canmount=noauto \
 		-O compression=on \
 		-O atime=off \
 		-R ${WRKDIR}/world ${zroot} /dev/${md}
@@ -502,7 +503,7 @@ cap_mkdb ${WRKDIR}/world/etc/login.conf
 
 # Set hostname
 if [ -n "${HOSTNAME}" ]; then
-	echo "hostname=${HOSTNAME}" >> ${WRKDIR}/world/etc/rc.conf
+	chroot ${WRKDIR}/world sh -c "echo \"hostname=${HOSTNAME}\" >> /etc/rc.conf"
 fi
 
 # Convert @flavor from package list to a unique entry of pkgname, otherwise it
@@ -838,9 +839,9 @@ zsnapshot)
 	;;
 zfssend*)
 	FINALIMAGE=${IMAGENAME}.zfs
-	zpool set bootfs=${zroot}/ROOT/default ${zroot}
+	zpool set bootfs=${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME} ${zroot}
 	zpool set autoexpand=on ${zroot}
-	zfs set canmount=noauto ${zroot}/ROOT/default
+	zfs set canmount=noauto ${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME}
 	SNAPSPEC="${zroot}@${IMAGENAME}"
 	case "${MEDIATYPE}" in
 	zfssend+be) SNAPSPEC="${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME}@${IMAGENAME}" ;;

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -597,16 +597,15 @@ installpackages_localmirror() {
 }
 
 installpackages_customrepo() {
-	PKGENV="env ASSUME_ALWAYS_YES=yes SYSLOG=no"
+	export ASSUME_ALWAYS_YES=yes SYSLOG=no
 	if [ "${arch}" != "${host_arch}" ]; then
-		PKGENV="${PKGENV} ABI=${arch} ABI_FILE=${WRKDIR}/world/usr/lib/crt1.o"
+		export ABI="${arch}" ABI_FILE="${WRKDIR}/world/usr/lib/crt1.o"
 	fi
-	echo "PKGENV: ${PKGENV}"
-	${PKGENV} pkg -r "${WRKDIR}/world/" install pkg
-	cat ${PACKAGELIST} | xargs ${PKGENV} pkg -r "${WRKDIR}/world/" install
-	convert_package_list "${PACKAGELIST}" | \
-	    xargs ${PKGENV} pkg -r "${WRKDIR}/world" \
-	    pkg install
+	pkg -c "${WRKDIR}/world/" install pkg
+
+	echo "" | awk -v pkglist="${PACKAGELIST}" \
+	    -f "${AWKPREFIX}/unique_pkgnames_from_flavored_origins.awk" | \
+	    xargs pkg -c "${WRKDIR}/world" install
 }
 
 # install packages if any is needed

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -274,7 +274,7 @@ while getopts "c:f:h:i:j:m:n:o:p:P:R:s:S:t:X:Y:z:Z:" FLAG; do
 			;;
 		Y)
 			[ -f "${OPTARG}" ] || err 1 "No such pre-export-script: ${OPTARG}"
-			PRE_EXPORT_SCRIPT="${OPTARG}"
+			PRE_EXPORT_SCRIPT=$(realpath ${OPTARG})
 			;;
 		X)
 			[ -r "${OPTARG}" ] || err 1 "No such exclude list ${OPTARG}"
@@ -561,8 +561,6 @@ convert_package_list() {
 	rm -rf "${PKG_DBDIR}" "${REPOS_DIR}"
 }
 
-# install packages if any is needed
-if [ -n "${PACKAGELIST}" ]; then
 installpackages_localmirror() {
 	mkdir -p ${WRKDIR}/world/tmp/packages
 	${NULLMOUNT} ${POUDRIERE_DATA}/packages/${MASTERNAME} ${WRKDIR}/world/tmp/packages
@@ -611,7 +609,6 @@ installpackages_customrepo() {
 }
 
 # install packages if any is needed
-echo "Reponame: ${PKGREPONAME}"
 if [ -n "${PACKAGELIST}" ]; then
 	if [ -n "${PKGREPONAME}" ]; then
 		installpackages_customrepo

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -3,6 +3,7 @@
 # Copyright (c) 2015 Baptiste Daroussin <bapt@FreeBSD.org>
 # All rights reserved.
 # Copyright (c) 2018 Allan Jude <allanjude@FreeBSD.org>
+# Copyright (c) 2019 Marie Helene Kvello-Aune <freebsd@mhka.no>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -2,7 +2,8 @@
 #
 # Copyright (c) 2015 Baptiste Daroussin <bapt@FreeBSD.org>
 # All rights reserved.
-#
+# Copyright (c) 2018 Allan Jude <allanjude@FreeBSD.org>
+# 
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
@@ -46,9 +47,10 @@ Parameters:
     -t type         -- Type of image can be one of (default iso+zmfs):
                     -- iso, iso+mfs, iso+zmfs, usb, usb+mfs, usb+zmfs,
                        rawdisk, zrawdisk, tar, firmware, rawfirmware,
-                       embedded, dump, zsnapshot
+                       embedded, dump, zfssend, zfssend+be, zsnapshot
     -X excludefile  -- File containing the list in cpdup format
     -z set          -- Set
+    -Z datasetfile  -- List of ZFS datasets to create
 EOF
 	exit 1
 }
@@ -130,10 +132,69 @@ mkminiroot() {
 	gzip -9 ${OUTPUTDIR}/${IMAGENAME}-miniroot
 }
 
+create_zfs_be_datasets() {
+	local OPT OPTSTR
+
+	if [ -n "$1" ]; then
+		. $1
+	fi
+	: ${ZFS_DATASETS:="
+		# DATASET	OPTIONS (space separated)
+
+		# Boot Environment [BE] root and default boot dataset
+		/$ZFS_BEROOT_NAME			mountpoint=none
+		/$ZFS_BEROOT_NAME/$ZFS_BOOTFS_NAME	mountpoint=/
+
+		# Compress /tmp, allow exec but not setuid
+		/tmp		mountpoint=/tmp exec=on setuid=off
+
+		# Don't mount /usr so that 'base' files go to the BEROOT
+		/usr		mountpoint=/usr canmount=off
+
+		# Home directories separated so they are common to all BEs
+		/usr/home	# NB: /home is a symlink to /usr/home
+
+		# Ports tree
+		/usr/ports	setuid=off
+
+		# Source tree (compressed)
+		/usr/src
+
+		# Create /var and friends
+		/var		mountpoint=/var canmount=off
+		/var/audit	exec=off setuid=off
+		/var/crash	exec=off setuid=off
+		/var/log	exec=off setuid=off
+		/var/mail	atime=on
+		/var/tmp	setuid=off
+	"}
+
+	msg "Creating ZFS Datasets"
+	echo "$ZFS_DATASETS" | while read dataset options; do
+		# Skip blank lines and comments
+		case "$dataset" in "#"*|"") continue; esac
+		# Remove potential inline comments in options
+		options="${options%%#*}"
+		# Replace tabs with spaces
+		str_replaceall "$options" "	" " " options
+		# Reduce contiguous runs of space to one single space
+		oldoptions=
+		while [ "$oldoptions" != "$options" ]; do
+			oldoptions="$options"
+			str_replaceall "$options" "  " " " options
+		done
+		# Replace both commas and spaces with ` -o '
+		str_replaceall "$options" "[ ,]" " -o " options
+		# Create the dataset with desired options
+		zfs create ${options:+-o $options} "$zroot$dataset" ||
+		    err 1 "Dataset creation failed"
+	done
+}
+
 . ${SCRIPTPREFIX}/common.sh
 HOSTNAME=poudriere-image
 
-while getopts "c:f:h:i:j:m:n:o:p:s:S:t:X:z:" FLAG; do
+while getopts "c:f:h:i:j:m:n:o:p:s:S:t:X:z:Z:" FLAG; do
 	case "${FLAG}" in
 		c)
 			[ -d "${OPTARG}" ] || err 1 "No such extract directory: ${OPTARG}"
@@ -184,7 +245,7 @@ while getopts "c:f:h:i:j:m:n:o:p:s:S:t:X:z:" FLAG; do
 			case ${MEDIATYPE} in
 			iso|iso+mfs|iso+zmfs|usb|usb+mfs|usb+zmfs) ;;
 			rawdisk|zrawdisk|tar|firmware|rawfirmware) ;;
-			embedded|dump|zsnapshot) ;;
+			embedded|dump|zfssend|zfssend+be) ;;
 			*) err 1 "invalid mediatype: ${MEDIATYPE}"
 			esac
 			;;
@@ -195,6 +256,14 @@ while getopts "c:f:h:i:j:m:n:o:p:s:S:t:X:z:" FLAG; do
 		z)
 			[ -n "${OPTARG}" ] || err 1 "Empty set name"
 			SETNAME="${OPTARG}"
+			;;
+		Z)
+			# If this is a relative path, add in ${PWD} as
+			# a cd / was done.
+			[ "${OPTARG#/}" = "${OPTARG}" ] && \
+			    OPTARG="${SAVED_PWD}/${OPTARG}"
+			[ -f "${OPTARG}" ] || err 1 "No such ZFS dataset list: ${OPTARG}"
+			DATASETLIST="${OPTARG}"
 			;;
 		*)
 			echo "Unknown flag '${FLAG}'"
@@ -209,6 +278,9 @@ post_getopts
 
 : ${MEDIATYPE:=none}
 : ${PTNAME:=default}
+: ${ZFS_SEND_FLAGS:=-Re}
+: ${ZFS_BEROOT_NAME:=ROOT}
+: ${ZFS_BOOTFS_NAME:=default}
 
 [ -n "${JAILNAME}" ] || usage
 
@@ -245,7 +317,7 @@ jail_exists ${JAILNAME} || err 1 "The jail ${JAILNAME} does not exist"
 _jget arch ${JAILNAME} arch || err 1 "Missing arch metadata for jail"
 get_host_arch host_arch
 case "${MEDIATYPE}" in
-usb|*firmware|*rawdisk|embedded|dump)
+usb|*firmware|*rawdisk|embedded|zfssend*)
 	[ -n "${IMAGESIZE}" ] || err 1 "Please specify the imagesize"
 	_jget mnt ${JAILNAME} mnt || err 1 "Missing mnt metadata for jail"
 	[ -f "${mnt}/boot/kernel/kernel" ] || \
@@ -392,6 +464,19 @@ zsnapshot)
 	if [ ! -z "${ORIGIN_IMAGE}" -a -f ${WRKDIR}/mnt/.version ]; then
 		PREVIOUS_SNAPSHOT_VERSION=$(cat ${WRKDIR}/mnt/.version)
 	fi
+	;;
+zfssend*)
+	truncate -s ${IMAGESIZE} ${WRKDIR}/raw.img
+	md=$(/sbin/mdconfig ${WRKDIR}/raw.img)
+	zroot=${IMAGENAME}root
+	msg "Creating temporary ZFS pool"
+	zpool create \
+		-O mountpoint=/${zroot} \
+		-O compression=on \
+		-O atime=off \
+		-R ${WRKDIR}/world ${zroot} /dev/${md}
+	create_zfs_be_datasets ${DATASETLIST}
+	chmod 1777 ${WRKDIR}/world/tmp ${WRKDIR}/world/var/tmp
 	;;
 esac
 
@@ -599,6 +684,11 @@ zrawdisk)
 	vfs.root.mountfrom="zfs:${zroot}/ROOT/default"
 	EOF
 	;;
+zfssend*)
+	cat >> ${WRKDIR}/world/boot/loader.conf <<-EOF
+	zfs_load="YES"
+	EOF
+	;;
 tar)
 	if [ -n "${MINIROOT}" ]; then
 		mkminiroot
@@ -741,6 +831,36 @@ zsnapshot)
 	mv ${WRKDIR}/manifest.json ${OUTPUTDIR}/${FINALIMAGE}-${SNAPSHOT_NAME}.manifest.json
 	ln -s ${FINALIMAGE}-${SNAPSHOT_NAME}.manifest.json ${WRKDIR}/${FINALIMAGE}-latest.manifest.json
 	mv ${WRKDIR}/${FINALIMAGE}-latest.manifest.json ${OUTPUTDIR}/${FINALIMAGE}-latest.manifest.json
+	;;
+zfssend)
+	FINALIMAGE=${IMAGENAME}.zfs
+	zpool set bootfs=${zroot}/ROOT/default ${zroot}
+	zpool set autoexpand=on ${zroot}
+	zfs set canmount=noauto ${zroot}/ROOT/default
+	msg "Creating snapshot(s) for replication"
+	zfs snapshot -r ${zroot}@${IMAGENAME}
+	msg "Creating replication stream"
+	zfs send ${ZFS_SEND_FLAGS} ${zroot}@${IMAGENAME} > ${OUTPUTDIR}/${FINALIMAGE} ||
+	    err 1 "Failed to save ZFS replication stream"
+	zpool export ${zroot}
+	zroot=
+	/sbin/mdconfig -d -u ${md#md}
+	md=
+	;;
+zfssend+be)
+	FINALIMAGE=${IMAGENAME}.zfs
+	zpool set bootfs=${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME} ${zroot}
+	zpool set autoexpand=on ${zroot}
+	zfs set canmount=noauto ${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME}
+	msg "Creating snapshot(s) for replication"
+	zfs snapshot -r ${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME}@${IMAGENAME}
+	msg "Creating replication stream"
+	zfs send ${ZFS_SEND_FLAGS} ${zroot}/${ZFS_BEROOT_NAME}/${ZFS_BOOTFS_NAME}@${IMAGENAME} > ${OUTPUTDIR}/${FINALIMAGE} ||
+	    err 1 "Failed to save ZFS replication stream"
+	zpool export ${zroot}
+	zroot=
+	/sbin/mdconfig -d -u ${md#md}
+	md=
 	;;
 esac
 

--- a/src/share/poudriere/image.sh
+++ b/src/share/poudriere/image.sh
@@ -344,7 +344,7 @@ jail_exists ${JAILNAME} || err 1 "The jail ${JAILNAME} does not exist"
 _jget arch ${JAILNAME} arch || err 1 "Missing arch metadata for jail"
 get_host_arch host_arch
 case "${MEDIATYPE}" in
-usb|*firmware|*rawdisk|embedded|zfssend*)
+usb|*firmware|*rawdisk|embedded|dump|zfssend*)
 	[ -n "${IMAGESIZE}" ] || err 1 "Please specify the imagesize"
 	_jget mnt ${JAILNAME} mnt || err 1 "Missing mnt metadata for jail"
 	[ -f "${mnt}/boot/kernel/kernel" ] || \


### PR DESCRIPTION
Implement many new features in poudriere image:
* Can now create zfssend output for boot-env and full pool in one run
* More sensible approach to setting the images hostname
* Can now specify a custom pkg(8) repository (-P). It is assumed that the repository has been configured already, for example with the overlay directory (-c)
* Can now source an external script (-S) immediately before the image is exported. This is useful for executing common tasks on the image before distribution,
such as looking for secrets (and fail the image if any are found)
* Documentation

Sponsored by: Modirum MDPay